### PR TITLE
FOLIO-601 Fix date-time in examples

### DIFF
--- a/ramls/examples/vendor_collection.sample
+++ b/ramls/examples/vendor_collection.sample
@@ -262,7 +262,7 @@
       "changelogs": [
         {
           "description": "This is a sample note.",
-          "timestamp": "2008-53-15T03:53:00-07"
+          "timestamp": "2008-05-15T03:53:00-07:00"
         }
       ]
     }

--- a/ramls/examples/vendor_get.sample
+++ b/ramls/examples/vendor_get.sample
@@ -268,7 +268,7 @@
   "changelogs": [
     {
       "description": "This is a sample note.",
-      "timestamp": "2008-53-15T03:53:00-07"
+      "timestamp": "2008-05-15T03:53:00-07:00"
     }
   ]
 }

--- a/ramls/examples/vendor_post.sample
+++ b/ramls/examples/vendor_post.sample
@@ -268,7 +268,7 @@
   "changelogs": [
     {
       "description": "This is a sample note.",
-      "timestamp": "2008-53-15T03:53:00-07"
+      "timestamp": "2008-05-15T03:53:00-07:00"
     }
   ]
 }

--- a/ramls/examples/vendor_put.sample
+++ b/ramls/examples/vendor_put.sample
@@ -268,7 +268,7 @@
   "changelogs": [
     {
       "description": "This is a sample note.",
-      "timestamp": "2008-53-15T03:53:00-07"
+      "timestamp": "2008-05-15T03:53:00-07:00"
     }
   ]
 }


### PR DESCRIPTION
Fixes “validation for format date-time” messages from raml-cop